### PR TITLE
Draft jupyterhub readme changes

### DIFF
--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -53,7 +53,7 @@ c.DockerSpawner.volumes[host_tutorial_notebooks_dir] = {
 }
 
 
-readme = os.environ['JUPYTERHUB_README'] if os.environ['JUPYTERHUB_README'] else join(jupyterhub_data_dir, "README.ipynb")
+readme = os.environ['JUPYTERHUB_README']
 if os.path.exists(readme):
     c.DockerSpawner.volumes[readme] = {
         "bind": join(notebook_dir, "README.ipynb"),

--- a/birdhouse/config/jupyterhub/jupyterhub_config.py.template
+++ b/birdhouse/config/jupyterhub/jupyterhub_config.py.template
@@ -52,7 +52,8 @@ c.DockerSpawner.volumes[host_tutorial_notebooks_dir] = {
     "mode": "ro"
 }
 
-readme = join(jupyterhub_data_dir, "README.ipynb")
+
+readme = os.environ['JUPYTERHUB_README'] if os.environ['JUPYTERHUB_README'] else join(jupyterhub_data_dir, "README.ipynb")
 if os.path.exists(readme):
     c.DockerSpawner.volumes[readme] = {
         "bind": join(notebook_dir, "README.ipynb"),

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -26,7 +26,7 @@ export JUPYTER_LOGIN_BANNER_TOP_SECTION=""
 export JUPYTER_LOGIN_BANNER_BOTTOM_SECTION=""
 
 # Path to the README.ipynb for jupyterhub
-export JUPYTERHUB_README=""
++export JUPYTERHUB_README=$JUPYTERHUB_USER_DATA_DIR"/README.ipynb"
 
 # Folder inside "proxy" container to drop extra monitoring config
 export CANARIE_MONITORING_EXTRA_CONF_DIR="/conf.d"

--- a/birdhouse/default.env
+++ b/birdhouse/default.env
@@ -25,6 +25,9 @@ export JUPYTER_DEMO_USER_CPU_LIMIT="0.5"  # 50% of 1 CPU
 export JUPYTER_LOGIN_BANNER_TOP_SECTION=""
 export JUPYTER_LOGIN_BANNER_BOTTOM_SECTION=""
 
+# Path to the README.ipynb for jupyterhub
+export JUPYTERHUB_README=""
+
 # Folder inside "proxy" container to drop extra monitoring config
 export CANARIE_MONITORING_EXTRA_CONF_DIR="/conf.d"
 

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -363,6 +363,7 @@ services:
       - ./config/jupyterhub/jupyterhub_config.py:/srv/jupyterhub/jupyterhub_config.py:ro
       - ./config/jupyterhub/custom_templates:/custom_templates:ro
       - ${JUPYTERHUB_USER_DATA_DIR}:${JUPYTERHUB_USER_DATA_DIR}
+      - ${JUPYTERHUB_README}:${JUPYTERHUB_README}:ro
       - jupyterhub_data_persistence:/persist:rw
       - /var/run/docker.sock:/var/run/docker.sock:rw
     links:

--- a/birdhouse/docker-compose.yml
+++ b/birdhouse/docker-compose.yml
@@ -358,6 +358,7 @@ services:
       JUPYTER_DEMO_USER_MEM_LIMIT: ${JUPYTER_DEMO_USER_MEM_LIMIT}
       JUPYTER_DEMO_USER_CPU_LIMIT: ${JUPYTER_DEMO_USER_CPU_LIMIT}
       JUPYTER_GOOGLE_DRIVE_SETTINGS: ${JUPYTER_GOOGLE_DRIVE_SETTINGS}
+      JUPYTERHUB_README: ${JUPYTERHUB_README}
     volumes:
       - ./config/jupyterhub/jupyterhub_config.py:/srv/jupyterhub/jupyterhub_config.py:ro
       - ./config/jupyterhub/custom_templates:/custom_templates:ro

--- a/birdhouse/env.local.example
+++ b/birdhouse/env.local.example
@@ -228,6 +228,9 @@ export POSTGRES_MAGPIE_PASSWORD=postgres-qwerty
 # checkbox agreeing to the terms and conditions.
 #export JUPYTER_LOGIN_TERMS_URL="https://host/path/to/terms"
 
+# Path to custom README for welcoming and guiding new users to Jupyterhub.
+#export JUPYTERHUB_README="/path/to/README.ipynb"
+
 # Extra PyWPS config for **all** WPS services (currently only Flyingpigeon, Finch and Raven supported).
 # export EXTRA_PYWPS_CONFIG="
 # [logging]


### PR DESCRIPTION
I'm not looking to merge this to my fork, but the main repo. I've set up this PR to act as a rough draft and a place to talk through the changes. 

@tlvu what I have here works for the case where I want to add a custom readme, but not for the default. The problem is the volume mount in `docker-compose.yml`, when there is no var set the mount breaks with the empty strings. A potential solution is to default the readme path to the existing path rather than an empty string and change how the default is checked. Do you have any suggestions on how best to solve this issue?